### PR TITLE
Add helper function to guard against unexpected size inflation.

### DIFF
--- a/src/FixMath.h
+++ b/src/FixMath.h
@@ -509,6 +509,18 @@ public:
   */
   static constexpr int8_t getNF() {return NF;}
 
+  /** Check wether this number exceeds the given total bitsize. Useful as a mechanism to guard
+   *  against unexpected bit size inflation. This is a compile-type check and will not incur
+   *  any flash use or performance penalty.
+   *
+   *  Example:
+   *  @code
+   *  auto a = toUInt((uint16_t) 42); // uint16_t is unecessarily large for this value, results in a UFix<16,0>
+   *  auto cubed = a*a*a;             // therefore, cubed is a UFix<48,0>
+   *  cubed.assertSize<32>();         // Oops, already at 48 bits! Should have used a smaller data type, above!
+   *  @endcode
+   */
+  template<int8_t BITS> static constexpr void assertSize() { static_assert(NI+NF <= BITS, "Data type is larger than expected!"); }
 private:
   template<int8_t, int8_t, uint64_t> friend class UFix;  // All sibling specializations shall be friends, too
   template<int8_t, int8_t, uint64_t> friend class SFix;
@@ -1004,6 +1016,9 @@ public:
   static constexpr int8_t getNF() {return NF;}
   
 
+  /** Check wether this number exceeds the given total bitsize. See UFix::asssertSize().
+   */
+  template<int8_t BITS> static constexpr void assertSize() { static_assert(NI+NF+1 <= BITS, "Data type is larger than expected!"); }
 private:
   template<int8_t, int8_t, uint64_t> friend class UFix;  // for access to UFixNIadj_t
   template<int8_t, int8_t, uint64_t> friend class SFix;

--- a/src/FixMath.h
+++ b/src/FixMath.h
@@ -509,9 +509,14 @@ public:
   */
   static constexpr int8_t getNF() {return NF;}
 
-  /** Check wether this number exceeds the given total bitsize. Useful as a mechanism to guard
-   *  against unexpected bit size inflation. This is a compile-type check and will not incur
-   *  any flash use or performance penalty.
+  /** Check wether this number exceeds the given total size given in bits, and produce a
+   *  compile time error, otherwise.
+   *
+   *  @note In the "sibling" function SFix::assertSize(), the sign bit is counted as an extra bit,
+   *        i.e. SFix<8,0>::assertSize<8>() will fail!
+   *
+   *  Useful as a mechanism to guard against unexpected bit size inflation. This is a compile-type check and
+   *  will not incur any flash use or performance penalty.
    *
    *  Example:
    *  @code
@@ -1016,7 +1021,10 @@ public:
   static constexpr int8_t getNF() {return NF;}
   
 
-  /** Check wether this number exceeds the given total bitsize. See UFix::asssertSize().
+  /** Check wether this number exceeds the given total size in bits. See UFix::asssertSize().
+   *
+   *  @note This function counts the number of bits needed, internally, and including the sign bit.
+   *        E.g. SFix<8,0>::assertSize<8>() will fail, as it requires 9 bits, internally!
    */
   template<int8_t BITS> static constexpr void assertSize() { static_assert(NI+NF+1 <= BITS, "Data type is larger than expected!"); }
 private:

--- a/src/FixMath_Autotests.h
+++ b/src/FixMath_Autotests.h
@@ -32,6 +32,7 @@ namespace FixMathPrivate {
       constexpr auto e = d + b + c;      // addition of one 9 (NI) bit and two 8 (NI) bit numbers needs promotion to 10 bits, not 11, only.
       static_assert(e.getNI() == 10);
       static_assert(e.getNF() == 2);
+      e.assertSize<12>();
       static_assert((d + d).getNI() == 10);
       static_assert((e + e).getNF() == 2);
       static_assert((d + e).getNI() == 11);


### PR DESCRIPTION
What do you think of this one?

I imagine a possible alternative / addition to this might be to allow to customize the bit limit (current hardcoded at 64) via a define. That could be used to ensure that no calculation anywhere exceeds a performant int range.