### PR TITLE
Trick to allow using FixMathPrivate inside the UFix and SFix classes,…

### DIFF
--- a/src/FixMath_Autotests.h
+++ b/src/FixMath_Autotests.h
@@ -11,7 +11,7 @@
 
 /** This file implements a few compile-time checks to verify the implementation is correct. */
  
-namespace FixMathPrivate {
+namespace FixMathPrivateTests {
   /* This function is never called, and has no effect, but simply encapsulates a bunch of static asserts */
   inline void static_autotests() {
     {


### PR DESCRIPTION
… without having to specify it, explicitly.

I just learned this new trick today on StackOverflow. Do you think it's worth it?

Pros:
 - Makes code easier to read.
Cons:
 - Not sure what doxygen will make of it.
 - The code is still hard to read.
 - If another lib / user code were to define ```FM_max()``` etc. *before* inclusion of FixMath.h, the name will clash. This problem will not occur the other way around, however, as the FixMathPrivate symbols are not introduced into the global namespace.

As a possible partial workaround for the last con, instead of ```using namespace FixMathPrivate;```, we could write ```namespace FMP=FixMathPrivate;``` which would at least allow writing a short-hand ```FMP::FM_max()``` instead of ```FixMathPrivate::FM_max()```.