### PR TITLE
Allow certain tests to run on the Uno

### DIFF
--- a/src/FixMath_Autotests.h
+++ b/src/FixMath_Autotests.h
@@ -9,9 +9,10 @@
  */
 
 #if (defined(__GNUC__) && (__GNUC__ < 12)) || (__cplusplus >= 202002L)
-// several of our tests require compilers to bit-shift of negative numbers is defined behavior (arithmetic shift), and can thus be used in
-// constexpr statements. This is not defined in the standard until C++ 2020. But older versions of GCC are less pedantic about checking, and
-// allow it at least for the cast of shift by 0 bits (-1 << 0). We leverage this fact to allow affected tests to run *somewhere* in our automated workflows (on the Uno at the time of this writing).
+// Bit-shifting negative number has not been formally defined behavior befor C++ 2020, but rather technically "implementation defined". It thus
+// could not be used in constexpr statements (although working quite fine, at runtime).
+// At the time of this writing (07/2024), we do not have a c++ 2020 compiler running in our automated test workflow. However, older versions of GCC
+// are less pedantic, and will regard at least the case of shift by 0 bits (-1 << 0) as defined. We leverage this fact to compile as many checks as possible.
 #define SHIFT_NEAGTIVE_BY_ZERO_DEFINED 1
 #else
 #define SHIFT_NEAGTIVE_BY_ZERO_DEFINED 0

--- a/src/FixMath_Autotests.h
+++ b/src/FixMath_Autotests.h
@@ -9,13 +9,13 @@
  */
 
 #if (defined(__GNUC__) && (__GNUC__ < 12)) || (__cplusplus >= 202002L)
-// Bit-shifting negative number has not been formally defined behavior befor C++ 2020, but rather technically "implementation defined". It thus
+// Bit-shifting negative number has not been formally defined behavior before C++ 2020, but rather technically "implementation defined". It thus
 // could not be used in constexpr statements (although working quite fine, at runtime).
 // At the time of this writing (07/2024), we do not have a c++ 2020 compiler running in our automated test workflow. However, older versions of GCC
 // are less pedantic, and will regard at least the case of shift by 0 bits (-1 << 0) as defined. We leverage this fact to compile as many checks as possible.
-#define SHIFT_NEAGTIVE_BY_ZERO_DEFINED 1
+#define SHIFT_NEGATIVE_BY_ZERO_DEFINED 1
 #else
-#define SHIFT_NEAGTIVE_BY_ZERO_DEFINED 0
+#define SHIFT_NEGATIVE_BY_ZERO_DEFINED 0
 #endif
 
 /** This file implements a few compile-time checks to verify the implementation is correct. */
@@ -50,7 +50,7 @@ namespace FixMathPrivate {
       static_assert(SFixAuto<127>().getNI() == 7, "test fail");
       static_assert(SFixAuto<128>().getNI() == 8, "test fail");
 
-#if SHIFT_NEAGTIVE_BY_ZERO_DEFINED
+#if SHIFT_NEGATIVE_BY_ZERO_DEFINED
       constexpr auto s = SFix<7,0>(-128);
       static_assert((s+s).getNI() == 8, "test fail");
       static_assert((-s).getNI() == 8, "test fail");


### PR DESCRIPTION
So as it turns out the thing that does work on the Uno is shifting negative values by 0 bits (-1 << 0). Adjusted the guard to address Uno more selectively, and limit it to cases, where this applies.